### PR TITLE
Derive controller_ip from controller_list

### DIFF
--- a/playbooks/roles/contrail/common/defaults/main.yml
+++ b/playbooks/roles/contrail/common/defaults/main.yml
@@ -1,8 +1,7 @@
 ---
 cloud_orchestrator: openstack
-controller_ip: "{{ ansible_default_ipv4.address }}"
-controller_list: ["{{ controller_ip }}"]
-
+controller_list: ["{{ ansible_default_ipv4.address }}"]
+controller_ip: "{{ controller_list[0] }}"
 config_server_list: "{{ controller_list }}"
 contrail_api_server_list: "{{ config_server_list }}"
 


### PR DESCRIPTION
Earlier it was other way around, which was mandating providing both
controller_list and controller_ip to make it work in multi-node
environment - even with single controller with separate compute. This
patch will change it - once somebody provide controller_list,
controller_ip will be derived from it(take first ip), if not provided.