### PR TITLE
Install contrail-vrouter-dkms as default contrail-vrouter package till logic is brought in

### DIFF
--- a/playbooks/roles/contrail/bare_metal_agent/defaults/main.yml
+++ b/playbooks/roles/contrail/bare_metal_agent/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # python-paramiko and ecdsa installed as workaround for bug https://bugs.launchpad.net/juniperopenstack/+bug/1669918
+# contrail-vrouter-dkms installed as workaround for bug https://bugs.launchpad.net/juniperopenstack/+bug/1664421
 agent_packages:
+  - contrail-vrouter-dkms
   - contrail-vrouter-common
   - contrail-setup
   - python-paramiko


### PR DESCRIPTION


Workaround for bug:
https://bugs.launchpad.net/juniperopenstack/+bug/1664421