### PR TITLE
Start agent container after node reboot

### DIFF
--- a/playbooks/roles/node/tasks/agent.yml
+++ b/playbooks/roles/node/tasks/agent.yml
@@ -77,7 +77,7 @@
     network_mode: host
     state: started
     tty: true
-    restart_retries: 3
+    restart_policy: unless-stopped
     pull: "{{ always_pull_image }}"
     capabilities:
       - AUDIT_WRITE


### PR DESCRIPTION
Restart policy was not added in agent container start code, and thus
agent container was not starting after reboot. This should fix that
behaviour