### PR TITLE
Make nova compute deployment optional (Fix 1665170)

### DIFF
--- a/playbooks/inventory/examples/fully_commented_inventory/group_vars/all.yml
+++ b/playbooks/inventory/examples/fully_commented_inventory/group_vars/all.yml
@@ -63,6 +63,11 @@ os_release: u14.04
 #
 # keystone_config: config params for keystone - these will go to [KEYSTONE] section of contrailctl/*.conf
 # keystone_config: {}
+#
+
+# Enable or disable openstack compute setup
+# This variable is only effective on cloud_controller is openstack
+# enable_openstack_compute: true
 
 # *** NOTE: Individual service/group commented configurations are kept in individual group based yaml files *** #
 # (e.g contrail-controller.yml for controller), - this is just to avoid one huge file, but all _config variables can be

--- a/playbooks/roles/common/defaults/main.yml
+++ b/playbooks/roles/common/defaults/main.yml
@@ -1,4 +1,5 @@
 ---
 contrail_compute_mode: bare_metal
+enable_openstack_compute: true
 deployment_platform: docker
 no_upstart: "{{ true if deployment_platform == 'docker' }}"

--- a/playbooks/site.yml
+++ b/playbooks/site.yml
@@ -25,7 +25,7 @@
     - name: Setup openstack compute in case of openstack
       role: openstack/compute
       tags: [openstack.compute]
-      when: cloud_orchestrator == "openstack"
+      when: cloud_orchestrator == "openstack" and enable_openstack_compute
 
   post_tasks:
     - name: Reboot node


### PR DESCRIPTION
Fixes: https://bugs.launchpad.net/juniperopenstack/+bug/1665170

only run openstack/compute if enable_openstack_compute is True