### PR TITLE
Adding docker log timeout to avoid errors

### DIFF
--- a/playbooks/roles/node/tasks/agent.yml
+++ b/playbooks/roles/node/tasks/agent.yml
@@ -63,6 +63,7 @@
   docker_image:
     name: contrail-agent
     tag: "{{ contrail_version }}"
+    timeout: "{{ container_image_load_timeout }}"
     load_path: "/tmp/{{ contrail_agent_image_archive }}"
   when: docker_registry is not defined or load_contrail_agent_image is defined
 


### PR DESCRIPTION
When loading docker images from the image, it may take long time before
docker can load the image and default timeout is 60 seconds which would
not be enough. Already fixed other places before and it was missed for
agent container image. This patch should fix this issue.