### PR TITLE
Remove haproxy package from bare metal compute install

### DIFF
--- a/playbooks/roles/contrail/bare_metal_agent/defaults/main.yml
+++ b/playbooks/roles/contrail/bare_metal_agent/defaults/main.yml
@@ -7,7 +7,6 @@ agent_packages:
   - contrail-setup
   - python-paramiko
   - python-ecdsa
-  - haproxy
 
 redhat_agent_packages:
   - python-Fabric


### PR DESCRIPTION
This package is not available in contrail-networking tgz and not needed on Bare Metal nodes