### PR TITLE
Avoid key errors when "contrail-compute" role is not present in inventory

### DIFF
--- a/playbooks/roles/node/tasks/main.yml
+++ b/playbooks/roles/node/tasks/main.yml
@@ -40,7 +40,7 @@
           ternary(hostvars[item]['ansible_all_ipv4_addresses'] |\
           ipaddr( ctrl_data_network ) | first, item)} ) }}"
   with_items:
-      - "{{ groups['contrail-analytics'] }}"
+      - "{{ analytics_group }}"
   when: ctrl_data_network is defined and analytics_list is not defined
 
 # Uses the analytics_dict dict created above and creates the final list
@@ -60,19 +60,19 @@
     analytics_list_tmp: "{{ analytics_list_tmp | default([]) + \
                          [hostvars[item].get('ctrl_data_ip', \
                          analytics_dict.get(item, item))] }}"
-  with_items: "{{ groups['contrail-analytics'] }}"
+  with_items: "{{ analytics_group }}"
   when: ctrl_data_network is defined and analytics_list is not defined
 
 - name: Create analytics_list - step 3 (with ctrl_data_ip if defined)
   set_fact:
     analytics_list_tmp: "{{ analytics_list_tmp | default([]) + \
                          [hostvars[item].get('ctrl_data_ip', item)] }}"
-  with_items: "{{ groups['contrail-analytics'] }}"
+  with_items: "{{ analytics_group }}"
   when: ctrl_data_network is not defined and analytics_list is not defined
 
 - name: Create analytics_list - step 4 (Assign from tmp if not defined)
   set_fact:
-      analytics_list: "{{ analytics_list_tmp }}"
+      analytics_list: "{{ analytics_list_tmp | default([]) }}"
   when: analytics_list is not defined
 
 
@@ -85,14 +85,14 @@
         ternary(hostvars[item]['ansible_all_ipv4_addresses'] | \
         ipaddr( ctrl_data_network ) | first, item)} ) }}"
   with_items:
-      - "{{ groups['contrail-analyticsdb'] }}"
+      - "{{ analyticsdb_group }}"
   when: ctrl_data_network is defined and analyticsdb_list is not defined
 
 - name: Create analyticsdb_list - step 2 (when ctrl_data_network is defined)
   set_fact:
     analyticsdb_list_tmp: "{{ analyticsdb_list_tmp | default([]) + \
                            [hostvars[item].get('ctrl_data_ip', item)] }}"
-  with_items: "{{ groups['contrail-analyticsdb'] }}"
+  with_items: "{{ analyticsdb_group }}"
   when: ctrl_data_network is not defined and analyticsdb_list is not defined
 
 - name: Create analyticsdb_list - step 3 (with ctrl_data_ip if defined)
@@ -100,12 +100,12 @@
     analyticsdb_list_tmp: "{{ analyticsdb_list_tmp | default([]) + \
                            [hostvars[item].get('ctrl_data_ip', \
                            analyticsdb_dict.get(item, item))] }}"
-  with_items: "{{ groups['contrail-analyticsdb'] }}"
+  with_items: "{{ analyticsdb_group }}"
   when: ctrl_data_network is defined and analyticsdb_list is not defined
 
 - name: Create analyticsdb_list - step 4 (Assign from tmp if not defined)
   set_fact:
-      analyticsdb_list: "{{ analyticsdb_list_tmp }}"
+      analyticsdb_list: "{{ analyticsdb_list_tmp | default([]) }}"
   when: analyticsdb_list is not defined
 
 
@@ -118,14 +118,14 @@
                       ternary(hostvars[item]['ansible_all_ipv4_addresses'] | \
                       ipaddr( ctrl_data_network ) | first, item)} ) }}"
   with_items:
-      - "{{ groups['contrail-controllers'] }}"
+      - "{{ controller_group }}"
   when: ctrl_data_network is defined and controller_list is undefined
 
 - name: Create controller_list - step 2 (when ctrl_data_network is defined)
   set_fact:
     controller_list_tmp: "{{ controller_list_tmp | default([]) + \
                       [hostvars[item].get('ctrl_data_ip', item)] }}"
-  with_items: "{{ groups['contrail-controllers'] }}"
+  with_items: "{{ controller_group }}"
   when: ctrl_data_network is not defined and controller_list is not defined
 
 - name: Create controller_list - step 3 (with ctrl_data_ip if defined)
@@ -133,12 +133,12 @@
     controller_list_tmp: "{{ controller_list_tmp | default([]) + \
                           [hostvars[item].get('ctrl_data_ip', \
                           controller_dict.get(item, item))] }}"
-  with_items: "{{ groups['contrail-controllers'] }}"
+  with_items: "{{ controller_group }}"
   when: ctrl_data_network is defined and controller_list is not defined
 
-- name: Create analytics_list - step 4 (Assign from tmp if not defined)
+- name: Create controller_list - step 4 (Assign from tmp if not defined)
   set_fact:
-      controller_list: "{{ controller_list_tmp }}"
+      controller_list: "{{ controller_list_tmp | default([]) }}"
   when: controller_list is not defined
 
 # Create compute_list
@@ -150,14 +150,14 @@
                    ternary(hostvars[item]['ansible_all_ipv4_addresses'] | \
                    ipaddr( ctrl_data_network ) | first, item)} ) }}"
   with_items:
-      - "{{ groups['contrail-compute'] }}"
+      - "{{ compute_group }}"
   when: ctrl_data_network is defined and compute_list is not defined
 
 - name: Create compute_list - step 2 (when ctrl_data_network is defined)
   set_fact:
     compute_list_tmp: "{{ compute_list_tmp | default([]) + \
                        [hostvars[item].get('ctrl_data_ip', item)] }}"
-  with_items: "{{ groups['contrail-compute'] }}"
+  with_items: "{{ compute_group }}"
   when: ctrl_data_network is not defined and compute_list is not defined
 
 - name: Create compute_list - step 3 (with ctrl_data_ip if defined)
@@ -165,12 +165,12 @@
     compute_list_tmp: "{{ compute_list_tmp | default([]) + \
                        [hostvars[item].get('ctrl_data_ip', \
                        compute_dict.get(item, item))] }}"
-  with_items: "{{ groups['contrail-compute'] }}"
+  with_items: "{{ compute_group }}"
   when: ctrl_data_network is defined and compute_list is not defined
 
 - name: Create compute_list - step 4 (Assign from tmp if not defined)
   set_fact:
-      compute_list: "{{ compute_list_tmp }}"
+      compute_list: "{{ compute_list_tmp | default([]) }}"
 
 - name: Create config_server_list_derived
   set_fact:
@@ -178,7 +178,7 @@
           [hostvars[item].get('ctrl_data_ip', controller_dict.get(item, item))]\
           if 'config' in hostvars[item].get('controller_components', []) \
           else config_server_list_derived}}"
-  with_items: "{{ groups['contrail-controllers'] }}"
+  with_items: "{{ controller_group }}"
   when: ctrl_data_network is defined
 
 - name: Create config_server_list_derived when ctrl_data_network is not defined
@@ -187,7 +187,7 @@
           [hostvars[item].get('ctrl_data_ip', item)] \
           if 'config' in hostvars[item].get('controller_components', []) \
           else config_server_list_derived}}"
-  with_items: "{{ groups['contrail-controllers'] }}"
+  with_items: "{{ controller_group }}"
   when: ctrl_data_network is not defined
 
 - include: lb.yml

--- a/playbooks/roles/node/vars/main.yml
+++ b/playbooks/roles/node/vars/main.yml
@@ -22,3 +22,8 @@ agent_config_orig: "{{ agent_config | default({}) | combine(\
   {'compile_vrouter_module': compile_vrouter_module_orig,\
   'vrouter_physical_interface': vrouter_physical_interface\
   })}}"
+
+controller_group: "{{ groups['contrail-controllers'] | default([]) }}"
+analytics_group: "{{ groups['contrail-analytics'] | default([]) }}"
+analyticsdb_group: "{{ groups['contrail-analyticsdb'] | default([]) }}"
+compute_group: "{{ groups['contrail-compute'] | default([]) }}"


### PR DESCRIPTION

Also applies to other list calculations

Use variables for controller/analytics/analyticsdb/compute groups