### PR TITLE
contrail_apt_repo is also defined in CentOS environments. 

### DIFF
--- a/playbooks/roles/docker/tasks/package.yml
+++ b/playbooks/roles/docker/tasks/package.yml
@@ -4,22 +4,22 @@
     repo: "deb {{ contrail_apt_repo }} ./"
     state: present
   register: apt_repo_added
-  when: contrail_apt_repo is defined
+  when: contrail_apt_repo is defined and contrail_apt_repo != ""
   ignore_errors: yes
 
 - name: Allow unauthenticated packages for contrail packages to work
   copy: content='APT::Get::AllowUnauthenticated "true";' dest=/etc/apt/apt.conf.d/99allowunauth
-  when: contrail_apt_repo is defined
+  when: contrail_apt_repo is defined and contrail_apt_repo != ""
 
 # If installing contrail_apt_repo entry, use higher priority for that to make
 # sure all packages use the contrail repo
 - name: Pin contrail apt repo "contrail" release to priority 999
   copy: src=apt-preferences.conf dest=/etc/apt/preferences.d/contrail_repo.pref
-  when: contrail_apt_repo is defined and apt_repo_added.get('changed',false)
+  when: contrail_apt_repo is defined and contrail_apt_repo != "" and apt_repo_added.get('changed',false)
 
 - name: Run apt-get update
   apt: update_cache=yes
-  when: contrail_apt_repo is defined and apt_repo_added.get('changed',false)
+  when: contrail_apt_repo is defined and contrail_apt_repo != "" and apt_repo_added.get('changed',false)
   ignore_errors: yes
 
 - name: install docker using package

--- a/playbooks/roles/node/defaults/main.yml
+++ b/playbooks/roles/node/defaults/main.yml
@@ -63,8 +63,8 @@ contrailctl_config_directory: /etc/contrailctl
 contrail_apt_repo_port: 1567
 contrail_yum_repo_port: "{{ contrail_apt_repo_port }}"
 contrail_repo_ip: "{{ hostvars[groups['contrail-repo'][0]].get('ansible_default_ipv4', {}).get('address','') | default('') if 'contrail-repo' in groups else ''}}"
-contrail_apt_repo: "{{ contrail_repo_ip | ternary('http://' + contrail_repo_ip + ':' + contrail_apt_repo_port|string, '') if 'contrail-repo' in groups else ''}}"
-contrail_yum_repo: "{{ contrail_repo_ip | ternary('http://' + contrail_repo_ip + ':' + contrail_yum_repo_port|string, '') if 'contrail-repo' in groups else ''}}"
+contrail_apt_repo: "{{ contrail_repo_ip | ternary('http://' + contrail_repo_ip + ':' + contrail_apt_repo_port|string, '') if 'contrail-repo' in groups and ansible_os_family == 'Debian' else '' }}"
+contrail_yum_repo: "{{ contrail_repo_ip | ternary('http://' + contrail_repo_ip + ':' + contrail_yum_repo_port|string, '') if 'contrail-repo' in groups and ansible_os_family == 'RedHat' else '' }}"
 
 # contrailctl_config_mode should be either
 #  configure - let ansible write contrailctl config entries using inifile module

--- a/playbooks/roles/node/tasks/host/Debian.yml
+++ b/playbooks/roles/node/tasks/host/Debian.yml
@@ -6,7 +6,7 @@
     repo: "deb {{ contrail_apt_repo }} ./"
     state: present
   register: apt_repo_added
-  when: contrail_apt_repo is defined
+  when: contrail_apt_repo is defined and contrail_apt_repo != ""
   ignore_errors: yes
 
 - name: Allow unauthenticated packages for contrail packages to work


### PR DESCRIPTION
Tasks depending on this variable should check if the variable is not an empty string.
Now on a Debian platform, contrail_yum_repo will be an empty string and on a RedHat platform, contrail_apt_repo will be an empty string.