### PR TITLE
Fix for docker-engine installation on 16.04 systems:

### DIFF
--- a/playbooks/roles/docker/handlers/main.yml
+++ b/playbooks/roles/docker/handlers/main.yml
@@ -1,7 +1,7 @@
 ---
-- name: restart docker
-  service: name=docker state=restarted
-
 - name: reload systemd
   command: /bin/systemctl daemon-reload
+
+- name: restart docker
+  service: name=docker state=restarted
 

--- a/playbooks/roles/docker/tasks/installer.yml
+++ b/playbooks/roles/docker/tasks/installer.yml
@@ -6,19 +6,3 @@
   shell: curl -s -L {{docker_mirror}} | sh
   args:
     creates: /usr/bin/docker
-
-- name: Added OPTIONS to docker start in case of using installer
-  ini_file: dest=/usr/lib/systemd/system/docker.service section=Service option=ExecStart value="/usr/bin/dockerd ${{ docker_options_var }}" create=no
-  ignore_errors: yes
-  when: ansible_service_mgr == "systemd"
-  notify:
-    - reload systemd
-    - restart docker
-
-- name: Added OPTIONS to docker start in case of using installer
-  ini_file: dest=/lib/systemd/system/docker.service section=Service option=ExecStart value="/usr/bin/dockerd ${{ docker_options_var }}" create=no
-  ignore_errors: yes
-  when: ansible_service_mgr == "systemd"
-  notify:
-    - reload systemd
-    - restart docker

--- a/playbooks/roles/docker/tasks/main.yml
+++ b/playbooks/roles/docker/tasks/main.yml
@@ -36,6 +36,23 @@
   notify: restart docker
   when: ansible_os_family == 'Debian' or ansible_distribution == 'CentOS'
 
+- name: Added OPTIONS to docker start in /usr/lib/systemd/system/docker.service
+  ini_file: dest=/usr/lib/systemd/system/docker.service section=Service option=ExecStart value="/usr/bin/dockerd ${{ docker_options_var }}" create=no
+  ignore_errors: yes
+  when: ansible_service_mgr == "systemd"
+  notify:
+    - reload systemd
+    - restart docker
+
+- name: Added OPTIONS to docker start in /lib/systemd/system/docker.service
+  ini_file: dest=/lib/systemd/system/docker.service section=Service option=ExecStart value="/usr/bin/dockerd ${{ docker_options_var }}" create=no
+  ignore_errors: yes
+  when: ansible_service_mgr == "systemd"
+  notify:
+    - reload systemd
+    - restart docker
+
+
 - name: Adding Docker Insecure registries in RedHat
   lineinfile: dest="{{ docker_env_file }}"
               line="{{docker_opts_RedHat}}"


### PR DESCRIPTION
1. systemd related configurations are required for both installer based
installation as well as package based installation. So moved those tasks to
tasks/main.yml
2. systemd daemon reload must occur before docker service is restarted.
Rreorderd the handlers to ensure this.